### PR TITLE
MOB-432 : Language picker hangs forever when trying to type in a language

### DIFF
--- a/Sources/PanelPresenter/Controllers/PanelPresentationController.swift
+++ b/Sources/PanelPresenter/Controllers/PanelPresentationController.swift
@@ -201,7 +201,6 @@ extension PanelPresentationController {
 
 	/// Attempts to update the panel's layout, allowing the caller to perform this logic with an animation
 	public func layoutIfNeeded() {
-		containerView?.setNeedsLayout()
 		containerView?.layoutIfNeeded()
 	}
 


### PR DESCRIPTION
This badly named `layoutIfNeeded` is also invalidating the layout. This seems to be because the layout relies on the keyboard frame, which is being manually stored during `keyboard**Will**ChangeFrameNotification`.

The crash/hang occurs when the keyboard dismiss is initiated by a swipe gesture on the table view.

Removing `containerView?.setNeedsLayout()` fixes the bug, and doesn't seem to have any detrimental impact on the layout of the panels subviews.